### PR TITLE
Template validate endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ import (
 
 client := postmark.NewClient("[SERVER-TOKEN]", "[ACCOUNT-TOKEN]")
 
-email := postmark.Email{    
+email := postmark.Email{
 	From: "no-reply@example.com",
 	To: "tito@example.com",
 	Subject: "Reset your password",
@@ -72,7 +72,7 @@ client.HTTPClient = urlfetch.Client(ctx)
     * [x] `GET /templates/:id`
     * [x] `PUT /templates/:id`
     * [x] `DELETE /templates/:id`
-    * [ ] `POST /templates/validate`
+    * [x] `POST /templates/validate`
 * [x] Servers
     * [x] `GET /servers/:id`
     * [x] `PUT /servers/:id`
@@ -116,4 +116,4 @@ client.HTTPClient = urlfetch.Client(ctx)
     * [ ] Inbound rules triggers
         * [ ] Create a trigger for inbound rule
         * [ ] Delete a single trigger
-        * [ ] List triggers    
+        * [ ] List triggers

--- a/templates.go
+++ b/templates.go
@@ -123,6 +123,45 @@ func (client *Client) DeleteTemplate(templateID string) error {
 	return err
 }
 
+type ValidateTemplateBody struct {
+	Subject                    string
+	TextBody                   string
+	HTMLBody                   string `json:"HtmlBody"`
+	TestRenderModel            map[string]interface{}
+	InlineCSSForHTMLTestRender bool `json:"InlineCssForHtmlTestRender"`
+}
+
+type ValidateTemplateResponse struct {
+	AllContentIsValid      bool
+	HTMLBody               Validation `json:"HtmlBody"`
+	TextBody               Validation
+	Subject                Validation
+	SuggestedTemplateModel map[string]interface{}
+}
+
+type Validation struct {
+	ContentIsValid   bool
+	ValidationErrors []ValidationError
+	RenderedContent  string
+}
+
+type ValidationError struct {
+	Message           string
+	Line              int
+	CharacterPosition int
+}
+
+func (client *Client) ValidateTemplate(validateTemplateBody ValidateTemplateBody) (ValidateTemplateResponse, error) {
+	res := ValidateTemplateResponse{}
+	err := client.doRequest(parameters{
+		Method:    "POST",
+		Path:      "templates/validate",
+		Payload:   validateTemplateBody,
+		TokenType: server_token,
+	}, &res)
+	return res, err
+}
+
 ///////////////////////////////////////
 ///////////////////////////////////////
 

--- a/templates.go
+++ b/templates.go
@@ -123,6 +123,10 @@ func (client *Client) DeleteTemplate(templateID string) error {
 	return err
 }
 
+///////////////////////////////////////
+///////////////////////////////////////
+
+// ValidateTemplateBody contains the template/render model combination to be validated
 type ValidateTemplateBody struct {
 	Subject                    string
 	TextBody                   string
@@ -131,6 +135,7 @@ type ValidateTemplateBody struct {
 	InlineCSSForHTMLTestRender bool `json:"InlineCssForHtmlTestRender"`
 }
 
+// ValidateTemplateResponse contains information as to how the validation went
 type ValidateTemplateResponse struct {
 	AllContentIsValid      bool
 	HTMLBody               Validation `json:"HtmlBody"`
@@ -139,18 +144,21 @@ type ValidateTemplateResponse struct {
 	SuggestedTemplateModel map[string]interface{}
 }
 
+// Validation contains the results of a field's validation
 type Validation struct {
 	ContentIsValid   bool
 	ValidationErrors []ValidationError
 	RenderedContent  string
 }
 
+// ValidationError contains information about the errors which occurred during validation for a given field
 type ValidationError struct {
 	Message           string
 	Line              int
 	CharacterPosition int
 }
 
+// ValidateTemplate validates the provided template/render model combination
 func (client *Client) ValidateTemplate(validateTemplateBody ValidateTemplateBody) (ValidateTemplateResponse, error) {
 	res := ValidateTemplateResponse{}
 	err := client.doRequest(parameters{

--- a/templates_test.go
+++ b/templates_test.go
@@ -188,7 +188,7 @@ func TestValidateTemplate(t *testing.T) {
 		  }
 	}`
 
-	tMux.HandleFunc(pat.Delete("/templates/:templateID"), func(w http.ResponseWriter, req *http.Request) {
+	tMux.HandleFunc(pat.Post("/templates/validate"), func(w http.ResponseWriter, req *http.Request) {
 		w.Write([]byte(responseJSON))
 	})
 

--- a/templates_test.go
+++ b/templates_test.go
@@ -195,8 +195,8 @@ func TestValidateTemplate(t *testing.T) {
 	res, err := client.ValidateTemplate(ValidateTemplateBody{
 		Subject:  "{{#company}}{{name}}{{/company}} {{subjectHeadline}}",
 		TextBody: "{{#company}}{{address}}{{/company}}{{#each person}} {{name}} {{/each}}",
-		HtmlBody: "{{#company}}{{phone}}{{/company}}{{#each person}} {{name}} {{/each}}",
-		TestRenderModel: map[string]string{
+		HTMLBody: "{{#company}}{{phone}}{{/company}}{{#each person}} {{name}} {{/each}}",
+		TestRenderModel: map[string]interface{}{
 			"userName": "bobby joe",
 		},
 		InlineCSSForHTMLTestRender: false,

--- a/templates_test.go
+++ b/templates_test.go
@@ -148,6 +148,69 @@ func TestDeleteTemplate(t *testing.T) {
 	}
 }
 
+func TestValidateTemplate(t *testing.T) {
+	responseJSON := `{
+		{
+			"AllContentIsValid": true,
+			"HtmlBody": {
+			  "ContentIsValid": true,
+			  "ValidationErrors": [],
+			  "RenderedContent": "address_Value name_Value "
+			},
+			"TextBody": {
+			  "ContentIsValid": true,
+			  "ValidationErrors": [{
+				  "Message" : "The syntax for this template is invalid.",
+				  "Line" : 1,
+				  "CharacterPosition" : 1
+			  }],
+			  "RenderedContent": "phone_Value name_Value "
+			},
+			"Subject": {
+			  "ContentIsValid": true,
+			  "ValidationErrors": [],
+			  "RenderedContent": "name_Value subjectHeadline_Value"
+			},
+			"SuggestedTemplateModel": {
+			  "userName": "bobby joe",
+			  "company": {
+				"address": "address_Value",
+				"phone": "phone_Value",
+				"name": "name_Value"
+			  },
+			  "person": [
+				{
+				  "name": "name_Value"
+				}
+			  ],
+			  "subjectHeadline": "subjectHeadline_Value"
+			}
+		  }
+	}`
+
+	tMux.HandleFunc(pat.Delete("/templates/:templateID"), func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte(responseJSON))
+	})
+
+	res, err := client.ValidateTemplate(ValidateTemplateBody{
+		Subject:  "{{#company}}{{name}}{{/company}} {{subjectHeadline}}",
+		TextBody: "{{#company}}{{address}}{{/company}}{{#each person}} {{name}} {{/each}}",
+		HtmlBody: "{{#company}}{{phone}}{{/company}}{{#each person}} {{name}} {{/each}}",
+		TestRenderModel: map[string]string{
+			"userName": "bobby joe",
+		},
+		InlineCSSForHTMLTestRender: false,
+	})
+
+	if err != nil {
+		t.Fatalf("ValidateTemplate: %s", err.Error())
+	}
+
+	if !res.AllContentIsValid {
+		t.Fatalf("ValidateTemplate: AllContentIsValid should be true")
+	}
+}
+
 var testTemplatedEmail = TemplatedEmail{
 	TemplateId: 1234,
 	TemplateModel: map[string]interface{}{


### PR DESCRIPTION
Adds the `templates/validate` endpoint handler function, along with new types:
- `ValidateTemplateBody`
- `ValidateTemplateResponse`
- `Validation`
- `ValidationError`